### PR TITLE
Add option to coerce boolean string/number values

### DIFF
--- a/src/__tests__/validation.spec.ts
+++ b/src/__tests__/validation.spec.ts
@@ -201,6 +201,35 @@ it('allows converting a number into a string', () => {
     })
 })
 
+it('allows coercing a boolean string/number into a boolean', () => {
+    const result1 = validateObjectShape(
+        'Test obj',
+        {
+            testBooleanNumber: 1,
+            testBooleanNumberFalse: 0,
+            testBooleanString: 'true',
+            testBooleanStringFalse: 'false'
+        },
+        {
+            testBooleanNumber: 'boolean',
+            testBooleanNumberFalse: 'boolean',
+            testBooleanString: 'boolean',
+            testBooleanStringFalse: 'boolean'
+        },
+        { coerceBooleans: true }
+    )
+
+    expect(result1).toMatchObject({
+        valid: true,
+        result: {
+            testBooleanNumber: true,
+            testBooleanNumberFalse: false,
+            testBooleanString: true,
+            testBooleanStringFalse: false
+        }
+    })
+})
+
 it('when wrapping an item in a array ensure it coerced correctly', () => {
     const result1 = validateObjectShape(
         'Test obj',

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,7 @@ export interface ValidationOptions {
      * be valid if inside an array, it will automatically be wrapped
      */
     coerceValidObjectIntoArray?: boolean
+    coerceBooleans?: boolean
 }
 
 export interface OptionalShape<T> {
@@ -240,6 +241,15 @@ export function validateValue<T extends ValidationKeyType<any>>(
 
     if (valueType === 'boolean') {
         if (typeof value !== 'boolean') {
+            if (options.coerceBooleans) {
+                if (value === 'true' || value === 1) {
+                    return { valid: true, result: true }
+                }
+                if (value === 'false' || value === 0) {
+                    return { valid: true, result: false }
+                }
+            }
+
             const errorMessage = `Expected ${valueDescription} to be type: boolean, was ${typeof value}`
             return {
                 valid: false,


### PR DESCRIPTION
Ran into a situation where a "true" value was failing validation, I feel like given this library coerces other string/number values to their respective types that this would be a good place to do the same with booleans